### PR TITLE
Rename plugin & fix doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## Plugin information
-This plugin provides 1 recipes that helps user retrieving data from BigQuery complex type.
+This plugin provides 1 recipe that helps user retrieving data from BigQuery complex type.
 
-Using the Flatten Receipe, the user can unnest Objects columns (create multiple columns from a single Object column) and/or unfold Array columns (create a row per element in the array).
+Using the Flatten Recipe, the user can unnest Objects columns (create multiple columns from a single Object column) and/or unfold Array columns (create a row per element in the array).
 
 ## Copyright notice
 Original work Copyright (c) 2021 Pierre Bailly-Ferry
-# dss-plugin-bigquery-complextypes-toolkit
+# dss-plugin-bigquery-toolkit

--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 ## Plugin information
-This plugin provides several tools to use images in machine learning applications. You can use a pre trained model to score images and obtain classes, or for feature extraction (obtaining the values taken by a layer for each image). You can also retrain a model to specialize it on a particular set of images, this process is known as transfer learning.
+This plugin provides 1 recipes that helps user retrieving data from BigQuery complex type.
 
-This plugin relies on the Keras library. Keras is an open source neural network library written in Python. We use it to run on top of the TensorFlow library as it enables fast experimentation with deep neural networks.
-
-This plugin provides a total of 3 recipes, a macro and a webapp template.
-
-This plugin will require the standard tensorflow package and runs on the CPU. Use the other plugin to enable GPU computation.
+Using the Flatten Receipe, the user can unnest Objects columns (create multiple columns from a single Object column) and/or unfold Array columns (create a row per element in the array).
 
 ## Copyright notice
-Original work Copyright (c) 2016 François Chollet
-# dss-plugin-big-query
+Original work Copyright (c) 2021 Pierre Bailly-Ferry
+# dss-plugin-bigquery-complextypes-toolkit

--- a/js/recipeController.js
+++ b/js/recipeController.js
@@ -63,7 +63,7 @@ app.directive('mappingNested', function(Debounce, $timeout) {
             fullWidthList: '<',
             pathList: '='
         },
-        templateUrl : '/plugins/bigquery-complextypes-toolkit/resource/templates/mapping-nested.html',
+        templateUrl : '/plugins/dss-plugin-bigquery-toolkit/resource/templates/mapping-nested.html',
         compile: () => ({
             pre: function (scope, element, attrs) {
                 if (angular.isUndefined(scope.mapping)) {

--- a/js/recipeController.js
+++ b/js/recipeController.js
@@ -63,7 +63,7 @@ app.directive('mappingNested', function(Debounce, $timeout) {
             fullWidthList: '<',
             pathList: '='
         },
-        templateUrl : '/plugins/bigquery/resource/templates/mapping-nested.html',
+        templateUrl : '/plugins/bigquery-complextypes-toolkit/resource/templates/mapping-nested.html',
         compile: () => ({
             pre: function (scope, element, attrs) {
                 if (angular.isUndefined(scope.mapping)) {

--- a/plugin.json
+++ b/plugin.json
@@ -1,9 +1,9 @@
 {
-    "id": "bigquery",
+    "id": "bigquery-complextypes-toolkit",
     "version": "1.0.0",
     "meta": {
-        "label": "BigQuery Flatten",
-        "description": "Flatten BigQuery datasets containing Object or Array columns.",
+        "label": "BigQuery complex types toolkit",
+        "description": "Tools to flatten BigQuery datasets containing Object or Array columns.",
         "author": "Dataiku",
         "icon": "icon-google-bigquery",
         "licenseInfo": "Apache Software License",

--- a/plugin.json
+++ b/plugin.json
@@ -1,8 +1,8 @@
 {
-    "id": "bigquery-complextypes-toolkit",
+    "id": "dss-plugin-bigquery-toolkit",
     "version": "1.0.0",
     "meta": {
-        "label": "BigQuery complex types toolkit",
+        "label": "BigQuery toolkit",
         "description": "Tools to flatten BigQuery datasets containing Object or Array columns.",
         "author": "Dataiku",
         "icon": "icon-google-bigquery",

--- a/resource/helpers/recipes-helper.py
+++ b/resource/helpers/recipes-helper.py
@@ -1,6 +1,6 @@
 import dataiku
 
-PLUGIN_ID = 'bigquery'
+PLUGIN_ID = 'bigquery-complextypes-toolkit'
 
 def do(payload, config, plugin_config, inputs):
     dataset = dataiku.Dataset(inputs[0]["fullName"])

--- a/resource/helpers/recipes-helper.py
+++ b/resource/helpers/recipes-helper.py
@@ -1,6 +1,6 @@
 import dataiku
 
-PLUGIN_ID = 'bigquery-complextypes-toolkit'
+PLUGIN_ID = 'dss-plugin-bigquery-toolkit'
 
 def do(payload, config, plugin_config, inputs):
     dataset = dataiku.Dataset(inputs[0]["fullName"])


### PR DESCRIPTION
[ch65233](https://app.clubhouse.io/dataiku/story/65233/bigquery-release-flatten-plugin)

Rename plugin and improve the documentation to be release-ready.

Warning: we may also want to rename the github, from `dss-plugin-big-query` to `dss-plugin-bigquery-complextypes-toolkit`.